### PR TITLE
HTML fix

### DIFF
--- a/kahoot-html/main.go
+++ b/kahoot-html/main.go
@@ -23,14 +23,14 @@ func main() {
 	}
 	nickname := os.Args[2]
 
-	for _, prefix := range []string{"<h1>", "<u>", "<h2>", "<marquee>", "<button>",
-		"<input>", "<pre>", "<textarea>"} {
+	for _, prefix := range []string{"h1", "u", "h2", "marquee", "button",
+		"input", "pre", "textarea", "b", "i"} {
 		if conn, err := kahoot.NewConn(gamePin); err != nil {
 			fmt.Fprintln(os.Stderr, "failed to connect:", err)
 			os.Exit(1)
 		} else {
 			defer conn.GracefulClose()
-			conn.Login(prefix + nickname)
+			conn.Login("<<a>" + prefix + ">" + nickname)
 		}
 	}
 


### PR DESCRIPTION
Add a buffer (```<a>```) to bypass HTML filter. Workflow:

1. Wanted username w/HTML: ```<h1>TEST```
2. Username changed to: ```<<a>h1>TEST```
3. Kahoot parses ```<a>``` to nothing
4. Final username: ```<h1>TEST```

Unfortunately kahoot has now server-side username length check so you cannot have much content in your name.