### PR TITLE
Fix for new Kahoot challenge

### DIFF
--- a/kahoot/sessions.go
+++ b/kahoot/sessions.go
@@ -43,7 +43,7 @@ func decipherToken(xToken, challenge string) (string, error) {
 		return "", fmt.Errorf("parse session token: %s", err)
 	}
 
-	challengeExpr := regexp.MustCompile("^\\(([0-9]*) \\+ ([0-9]*)\\) \\* ([0-9]*)$")
+	challengeExpr := regexp.MustCompile("^([0-9]*)\\) \\* ([0-9]*) \\+ \\(([0-9]*)$")
 	match := challengeExpr.FindStringSubmatch(challenge)
 	if match == nil {
 		return "", fmt.Errorf("unsupported challenge: %s", challenge)
@@ -52,7 +52,7 @@ func decipherToken(xToken, challenge string) (string, error) {
 	num1, _ := strconv.Atoi(match[1])
 	num2, _ := strconv.Atoi(match[2])
 	num3, _ := strconv.Atoi(match[3])
-	mask := []byte(strconv.Itoa((num1 + num2) * num3))
+	mask := []byte(strconv.Itoa(num1 * (num2 + num3))
 
 	for i := range rawToken {
 		rawToken[i] ^= mask[i%len(mask)]


### PR DESCRIPTION
Fix for the new challenge Kahoot seems to be using.

The previous format was `(a + b) * c`. This seems to have been changed to `a * (b + c)`.